### PR TITLE
Bring main callback to node.js error conventions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var http = require('http');
 var querystring = require('querystring');
-var response_code = require('./response_code.json')
+var response_code = require('./response_code.json');
 
 var SMSru = function(){
 	this.params = [];
@@ -94,10 +94,10 @@ SMSru.prototype = {
 						response[result[0]] = result[1];
 					}
 				})
-				callback(response);
+				callback(null, response);
 			}});
 		}).on('error', function(e) {
-		  console.log("Error: " + e.message);
+			callback(e);
 		});
 	},
 }


### PR DESCRIPTION
Bring main callback to node.js error conventions instead of having both error and response data in one variable, because actual response is not an error.
http://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions

So the actual call would look like 

``` javascript
sms.sms_send({
  to: '79112223344',
  text: 'Текст SMS'
}, function(error, response) {
    console.log(error, response))
})
```
